### PR TITLE
Feat: Add themed / monochrome launcher app icon

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>


### PR DESCRIPTION
### Adds Support for [Themed Launcher app icon](https://www.android.com/android-13/#a13-your-phone-your-aesthetic) on Android 13 & above.

[Documentation](https://developer.android.com/develop/ui/views/launch/icon_design_adaptive)
--- 
#### Examples:

- Dark theme, B&W swatch
![scr1_dark_bw](https://github.com/user-attachments/assets/157370e5-c7e6-4b25-a534-d5e3577fe7f3)

- Light theme, B&W swatch
![scr2_light_bw](https://github.com/user-attachments/assets/99280d5e-afb0-43a1-8da6-0a8098884a94)